### PR TITLE
Addresses Mantis 17932

### DIFF
--- a/Common/X509Cert.dyalog
+++ b/Common/X509Cert.dyalog
@@ -289,10 +289,10 @@
     ⍝ Establish a pointer to a Conga instance or a v2 DRC namspace
       :If ''≢LDRC ⋄ ldrc←LDRC ⍝ Ref already set
       :Else
-          :If 9=⎕NC'#.Conga' ⍝ Else use Conga factory function
-              ldrc←#.Conga.Init''
-          :ElseIf 9=⎕NC'#.DRC'   ⍝ Look for v2 DRC namespace
-              ldrc←#.DRC
+          :If 9=##.⎕NC'Conga'     ⍝ Else use Conga factory function
+              ldrc←##.Conga.Init''
+          :ElseIf 9=##.⎕NC'DRC'   ⍝ Look for v2 DRC namespace
+              ldrc←##.DRC
           :EndIf
       :EndIf
     ∇


### PR DESCRIPTION
Make X509Cert.FindDRC  look in parent (##) rather than root (#) for Conga/DRC
This is so that Conga can be copied into a namespace other than root.