### PR TITLE
Add :Hold to Conga.Init

### DIFF
--- a/v3/Conga/Init.dyalog
+++ b/v3/Conga/Init.dyalog
@@ -1,4 +1,4 @@
-﻿ ref←{libpath}Init arg;rootname;inst;ix;r;z;isLoaded;x
+ ref←{libpath}Init arg;rootname;inst;ix;r;z;isLoaded;x
  :If 0=⎕NC'libpath' ⋄ libpath←'' ⋄ :EndIf
 
  :Trap 0
@@ -16,17 +16,19 @@
 
  rootname←⊃((0≠≢arg)/enc arg)defaults,⊂'DEFAULT'
 
- isLoaded←3=⎕NC'⍙InitRPC'
- :If 0=⊃r←LoadSharedLib libpath ⍝ Sets LibPath as side-effect
-     :If isLoaded≠3=⎕NC'⍙InitRPC' ⍝ the shared lib has been loaded revitalize all the instances
-     :AndIf 0<≢x←⎕INSTANCES⊃⊃⎕CLASS LIB
-         x.LibPath←⊂LibPath
-         x.InitInstance
-     :EndIf
+ :Hold 'Conga.Init'
+     isLoaded←3=⎕NC'⍙InitRPC'
+     :If 0=⊃r←LoadSharedLib libpath ⍝ Sets LibPath as side-effect
+         :If isLoaded≠3=⎕NC'⍙InitRPC' ⍝ the shared lib has been loaded revitalize all the instances
+         :AndIf 0<≢x←⎕INSTANCES⊃⊃⎕CLASS LIB
+             x.LibPath←⊂LibPath
+             x.InitInstance
+         :EndIf
 
-     :If ⍬≡ref←FindInst rootname
-         ref←##.⎕NEW LIB(LibPath rootname) ⍝ NB always create instances in the parent space
+         :If ⍬≡ref←FindInst rootname
+             ref←##.⎕NEW LIB(LibPath rootname) ⍝ NB always create instances in the parent space
+         :EndIf
+     :Else
+         ('Unable to load shared library: ',⍕r)⎕SIGNAL 999
      :EndIf
- :Else
-     ('Unable to load shared library: ',⍕r)⎕SIGNAL 999
- :EndIf
+ :EndHold


### PR DESCRIPTION
Add :Hold around shared library initialization in Conga.Init to avoid potential problems when creating mulitple instances of Conga.LIB in rapid succession